### PR TITLE
Fix wrong method name in enterEvent

### DIFF
--- a/monolens/widget.py
+++ b/monolens/widget.py
@@ -45,7 +45,7 @@ class Widget(QWidget):
     def enterEvent(self, event):
         self.updateScreen()
         self._timer.start()
-        super(Widget, self).eventEvent(event)
+        super(Widget, self).enterEvent(event)
 
     def leaveEvent(self, event):
         self._timer.stop()


### PR DESCRIPTION
Fixes this error:

```
Traceback (most recent call last):
  File "/home/maxnoe/.local/lib/python3.9/site-packages/monolens/widget.py", line 48, in enterEvent
    super(Widget, self).eventEvent(event)
AttributeError: 'super' object has no attribute 'eventEvent'
```
When entering with the mouse.